### PR TITLE
Bugfix for SOS.Map.constructFeatureOfInterestLayerLoadHandlers().

### DIFF
--- a/web/js/SOS/SOS.Ui.js
+++ b/web/js/SOS/SOS.Ui.js
@@ -2417,29 +2417,10 @@ if(typeof OpenLayers !== "undefined" && OpenLayers !== null &&
         var scope = config.options.params.eventListeners.scope;
 
         /* Show a busy indicator whilst the FOI layer is loading.  If the user
-           has already specified load start/end event handlers, then we add a
-           busy indicator call to the end of the user's custom event handler */
-
-        if(config.options.params.eventListeners.loadstart) {
-          scope._sosMapFoiLoadstartHandlerOriginal = config.options.params.eventListeners.loadstart;
-          scope._sosMapFoiLoadstartHandler = this.constructBusyIndicatorStartHandler("#" + this.config.map.id);
-          config.options.params.eventListeners.loadstart = function(evt) {
-            scope._sosMapFoiLoadstartHandlerOriginal(evt);
-            scope._sosMapFoiLoadstartHandler(evt);
-          };
-        } else {
-          config.options.params.eventListeners.loadstart = this.constructBusyIndicatorStartHandler("#" + this.config.map.id);
-        }
-        if(config.options.params.eventListeners.loadend) {
-          scope._sosMapFoiLoadendHandlerOriginal = config.options.params.eventListeners.loadend;
-          scope._sosMapFoiLoadendHandler = this.constructBusyIndicatorEndHandler();
-          config.options.params.eventListeners.loadend = function(evt) {
-            scope._sosMapFoiLoadendHandlerOriginal(evt);
-            scope._sosMapFoiLoadendHandler(evt);
-          };
-        } else {
-          config.options.params.eventListeners.loadend = this.constructBusyIndicatorEndHandler();
-        }
+           has specified a scope, then the busy indicator calls run in that
+           scope */
+        config.options.params.eventListeners.loadstart = scope.constructBusyIndicatorStartHandler("#" + this.config.map.id);
+        config.options.params.eventListeners.loadend = scope.constructBusyIndicatorEndHandler();
       },
 
       /**


### PR DESCRIPTION
The SOS.Map.constructFeatureOfInterestLayerLoadHandlers() function has been simplified.  Before, if the showBusyIndicatorOnLoad option was set, and the user had specified a custom loadstart/loadend handler, the function would attempt to incorporate the user's custom loadstart/loadend handler, as well as a busy indicator.  Now it overwrites the user's custom handler, and so just calls the busy indicator.  See previous commit (185e304f1f3d3135aa2514db64379899a0533996).

The reason for this is that, in trying to incorporate both handlers, it creates temporary functions on the given scope object, which works OK.  However, in a long-lived app, where the map is redrawn many times, this results in the previously combined functions being incorporated again, eventually resulting in a fatal 'Too much recursion' bug.

All this means though, is that if the user wants this dual functionality, then they have to turn off the automatic creation of a busy indicator by setting showBusyIndicatorOnLoad = false, and then create the busy indicator start/end calls in their custom handler(s).

For example:

customFoiLayer.options = {
  showBusyIndicatorOnLoad: false,
  params: {
    eventListeners: {
      loadstart: this.customLoadstartHandler,
      loadend: this.constructBusyIndicatorEndHandler(),
      scope: this
    }
  }
};

customLoadstartHandler = function(evt) {
  // Start the busy indicator via a temporary function, then remove
  this._f = this.constructBusyIndicatorStartHandler("#id");
  this._f(evt);
  delete this._f;
  // Do other things whilst this layer is loading...
}